### PR TITLE
Add pre-push hook for linting and testing with CI integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,15 @@ jobs:
         uses: fkirc/skip-duplicate-actions@v5
         with:
           concurrent_skipping: 'same_content_newer'
+  fmt:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup-steps
+        uses: "./.github/templates/setup-steps"
+      - run: just fmt-check
   lint:
     needs: pre_job
     if: needs.pre_job.outputs.should_skip != 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,5 +11,6 @@ repos:
       entry: bash -c 'just pre-push'
       language: system
       always_run: true
+      types: [file]
 default_stages:
   - pre-push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,12 @@ repos:
   rev: v4.3.0
   hooks:
   - id: no-commit-to-branch
+- repo: local
+  hooks:
+    - id: pre-push
+      name: Lint & Test
+      entry: bash -c 'just pre-push'
+      language: system
+      always_run: true
+default_stages:
+  - pre-push

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 alias b := build
 alias t := test
 version := "1.0.0b1"
-pre-push: lint fmt test
+pre-push: lint fmt-check test
   @echo "All checks passed"
 build-only pkg_name:
   uv build --package {{pkg_name}}
@@ -10,6 +10,8 @@ build:
   uv build --package model-lib
 fix:
   uv run ruff check --fix .
+fmt-check:
+  uv run ruff format --check .
 fmt:
   uv run ruff format .
 lint:

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 alias b := build
 alias t := test
 version := "1.0.0b1"
-pre-push: lint test
+pre-push: lint fmt test
   @echo "All checks passed"
 build-only pkg_name:
   uv build --package {{pkg_name}}

--- a/model-lib/model_lib/metadata/context_dict.py
+++ b/model-lib/model_lib/metadata/context_dict.py
@@ -48,7 +48,7 @@ class CopyConfig:
     never: bool = False
     thread_copy: bool | Callable[[], bool] = False
     task_copy: bool | Callable[[], bool] = True
-    copy_func: Callable[[T], T] = identity # type: ignore
+    copy_func: Callable[[T], T] = identity  # type: ignore
     # is thread
     on_copy_done: ParentChildCopy | None = None
 
@@ -79,7 +79,7 @@ assert DEFAULT_CONFIG.copy_to_task
 
 def copy_value(key: KeyT, value: T) -> T:
     config = get_copy_behavior(key) or DEFAULT_CONFIG
-    return config.copy_func(value) # type: ignore
+    return config.copy_func(value)  # type: ignore
 
 
 def set_copy_behavior(t: KeyT, config: CopyConfig) -> None:
@@ -196,7 +196,7 @@ def clear_context_dict():
         return
     if old is ...:
         return
-    _context_dict.set(...) # type: ignore
+    _context_dict.set(...)  # type: ignore
 
 
 def get_context_instance(t: type[T]) -> T:

--- a/model-lib/model_lib/model_dump.py
+++ b/model-lib/model_lib/model_dump.py
@@ -60,8 +60,8 @@ def _register_yaml_dumper(instance_type: Type[T], dump_call: DumpCall):
             data = dump_call(instance)
             return dumper.represent_data(data)
 
-        yaml.add_multi_representer(instance_type, represent, yaml.SafeDumper) # type: ignore
-        yaml.add_multi_representer(instance_type, represent, yaml.Dumper) # type: ignore
+        yaml.add_multi_representer(instance_type, represent, yaml.SafeDumper)  # type: ignore
+        yaml.add_multi_representer(instance_type, represent, yaml.Dumper)  # type: ignore
 
 
 def register_dumper(
@@ -78,7 +78,7 @@ def register_dumper(
     dump.register(instance_type)(dump_call)
 
     def unregister():
-        return dump.unregister(instance_type) # type: ignore
+        return dump.unregister(instance_type)  # type: ignore
 
     _register_yaml_dumper(instance_type, dump_call)
 

--- a/model-lib/model_lib/pydantic_utils_test.py
+++ b/model-lib/model_lib/pydantic_utils_test.py
@@ -148,7 +148,7 @@ def test_utc_datetime_ms():
 
 def test_dumping_time_model():
     dt = parse_dt("2023-08-16T16:42:14.123456")
-    model = _TimeModel(utc=dt, utc_ms=dt, td=30) # type: ignore
+    model = _TimeModel(utc=dt, utc_ms=dt, td=30)  # type: ignore
     assert model.td == timedelta(seconds=30)
     expected_json = '{"utc":"2023-08-16T16:42:14.123456Z","utc_ms":"2023-08-16T16:42:14.123000Z","td":"PT30S"}'
     assert dump(model, "json") == expected_json

--- a/model-lib/model_lib/readme_example_test.py
+++ b/model-lib/model_lib/readme_example_test.py
@@ -26,7 +26,7 @@ expected_dump_formats: list[str] = [
     "toml",
     "toml_compact",
 ]
-missing_dump_formats: set[str] = set(FileFormat) - set(expected_dump_formats) # type: ignore
+missing_dump_formats: set[str] = set(FileFormat) - set(expected_dump_formats)  # type: ignore
 assert not missing_dump_formats, f"found missing dump formats: {missing_dump_formats}"
 
 

--- a/model-lib/model_lib/serialize/dump.py
+++ b/model-lib/model_lib/serialize/dump.py
@@ -39,7 +39,7 @@ def dump_as_toml_str_compact(
     # dumps to json and parse 1st to support custom types
     # and since an error will have a side effect on the instance creating a _TomlObject
     if isinstance(instance, list):
-        raw: list | dict = dump_as_list(instance) # type: ignore
+        raw: list | dict = dump_as_list(instance)  # type: ignore
     else:
         raw: dict = dump_as_dict(instance)  # type: ignore
     return dump_toml_str(

--- a/model-lib/model_lib/serialize/json_serialize.py
+++ b/model-lib/model_lib/serialize/json_serialize.py
@@ -15,12 +15,12 @@ T = TypeVar("T")
 dump_call: TypeAlias = Callable[[T], str]
 dump_parse: TypeAlias = Optional[tuple[dump_call, dump_call, Callable[[str], Any]]]
 
+
 def dump(instance: Any) -> str:
     if isinstance(instance, pydantic.BaseModel):
         return instance.model_dump_json()
-    return json.dumps(
-        instance, indent=None, separators=(",", ":"), default=model_dump
-    )
+    return json.dumps(instance, indent=None, separators=(",", ":"), default=model_dump)
+
 
 def pretty_dump(instance: Any) -> str:
     if isinstance(instance, pydantic.BaseModel):
@@ -32,5 +32,6 @@ def pretty_dump(instance: Any) -> str:
         ensure_ascii=False,
         default=model_dump,
     )
+
 
 parse = json.loads

--- a/model-lib/model_lib/serialize/parse.py
+++ b/model-lib/model_lib/serialize/parse.py
@@ -65,7 +65,7 @@ def create_model(
     model_kwargs = isinstance(model_args, dict)
     if extra_kwargs:
         return (
-            cls(**(model_args | extra_kwargs)) # type: ignore
+            cls(**(model_args | extra_kwargs))  # type: ignore
             if model_kwargs
             else cls(model_args, **extra_kwargs)  # type: ignore
         )
@@ -163,9 +163,7 @@ def get_parsers() -> dict[Type, PayloadParser]:
     return _registered_parsers
 
 
-def register_parser(
-    payload_type: Type, call: PayloadParser
-) -> None:
+def register_parser(payload_type: Type, call: PayloadParser) -> None:
     if previous := _registered_parsers.get(payload_type):
         raise PayloadParserAlreadyExistError(as_name(previous), as_name(call))
     _registered_parsers[payload_type] = call

--- a/model-lib/model_lib/serialize/toml_serialize.py
+++ b/model-lib/model_lib/serialize/toml_serialize.py
@@ -71,6 +71,7 @@ def dump_toml_str(data: object, **kwargs) -> str:
 
 
 
+
 _loads = toml.loads
 
 

--- a/model-lib/model_lib/serialize/toml_serialize.py
+++ b/model-lib/model_lib/serialize/toml_serialize.py
@@ -66,7 +66,9 @@ _dumps = toml.dumps
 
 
 def dump_toml_str(data: object, **kwargs) -> str:
-    return _dumps(data, **kwargs) # type: ignore
+    return _dumps(data, **kwargs)  # type: ignore
+
+
 
 
 _loads = toml.loads

--- a/model-lib/model_lib/serialize/toml_serialize.py
+++ b/model-lib/model_lib/serialize/toml_serialize.py
@@ -69,9 +69,6 @@ def dump_toml_str(data: object, **kwargs) -> str:
     return _dumps(data, **kwargs)  # type: ignore
 
 
-
-
-
 _loads = toml.loads
 
 

--- a/model-lib/model_lib/serialize/yaml_serialize.py
+++ b/model-lib/model_lib/serialize/yaml_serialize.py
@@ -54,7 +54,9 @@ def dump_yaml_str(
     return s.getvalue()
 
 
-def dump_yaml_file(path: PathLike| str, data: Mapping, width=1000, sort_keys: bool = False):
+def dump_yaml_file(
+    path: PathLike | str, data: Mapping, width=1000, sort_keys: bool = False
+):
     with open(path, "w") as f:
         yaml.safe_dump(
             data, stream=f, default_flow_style=False, width=width, sort_keys=sort_keys

--- a/model-lib/model_lib/serialize/yaml_test.py
+++ b/model-lib/model_lib/serialize/yaml_test.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 # flake8: noqa
 # otherwise pants will not include the file in the tests
-from model_lib.serialize import * # type: ignore
+from model_lib.serialize import *  # type: ignore
 from model_lib.serialize import yaml_serialize
 from model_lib.serialize.yaml_serialize import (
     _add_brackets,

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ flowchart TD
 - [Install `uv`](https://docs.astral.sh/uv/getting-started/installation/)
 
 ```sh
+pre-commit install --hook-type pre-push
 uv sync
 code .
 ```

--- a/uv.lock
+++ b/uv.lock
@@ -1274,5 +1274,5 @@ wheels = [
 
 [[package]]
 name = "zero-3rdparty"
-version = "1.0.0a4"
+version = "1.0.0b1"
 source = { editable = "zero-3rdparty" }

--- a/zero-3rdparty/zero_3rdparty/logging_utils.py
+++ b/zero-3rdparty/zero_3rdparty/logging_utils.py
@@ -28,7 +28,7 @@ class LimitMessageLength(logging.Filter):
             and len(msg) > self.length
         ):
             record.msg = record.msg[: self.length]
-        return super().filter(record) # type: ignore
+        return super().filter(record)  # type: ignore
 
 
 def limit_message_length(logger: logging.Logger | None = None) -> None:


### PR DESCRIPTION
Introduce a pre-push hook to enforce linting and testing before code is pushed. Update CI workflow to include a formatting job and ensure all files are checked during pre-push. Clean up related files and documentation for clarity.