### PR TITLE
ask-shell: binary resolution and ensure directory cleanup

### DIFF
--- a/ask-shell/ask_shell/__init__.py
+++ b/ask-shell/ask_shell/__init__.py
@@ -20,7 +20,7 @@ from ask_shell.rich_progress import new_task
 from ask_shell.run_pool import run_pool
 from ask_shell.typer_command import configure_logging
 
-VERSION = "0.0.4"
+VERSION = "0.0.5"
 __all__ = [
     "AskShellSettings",
     "ChoiceTyped",

--- a/ask-shell/ask_shell/public_api_test.py
+++ b/ask-shell/ask_shell/public_api_test.py
@@ -24,6 +24,7 @@ from ask_shell.models import (
     ShellRunPOpenStarted,
     ShellRunStdOutput,
     ShellRunStdStarted,
+    _mise_binary,
 )
 
 PYTHON_EXEC = sys.executable
@@ -340,3 +341,11 @@ def test_message_callbacks():
         ShellRunStdOutput.__name__,
         ShellRunAfter.__name__,
     ], f"Unexpected message class names: {message_class_names}"
+
+
+def test_mise_resolve(tmp_path):
+    mise = _mise_binary()
+    if not mise:
+        pytest.skip("mise binary not found")
+    result = run_and_wait("terraform version", cwd=tmp_path)
+    assert "not found" not in result.stdout_one_line

--- a/ask-shell/ask_shell/rich_run_state_test.py
+++ b/ask-shell/ask_shell/rich_run_state_test.py
@@ -40,7 +40,7 @@ def test_run_with_output_is_logged_to_console(settings, capture_console, caplog)
     assert "This is an error message." in output
     assert "Test error" in output
     log_output = caplog.text
-    assert "❌ 'echo \"Hello, World!\"'" in log_output
+    assert "❌ '/bin/echo \"Hello, World!\"'" in log_output
     assert not get_live().is_started
 
 

--- a/ask-shell/pyproject.toml
+++ b/ask-shell/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ask-shell"
-version = "0.0.4"
+version = "0.0.5"
 requires-python = ">=3.10"
 readme = "readme.md"
 dependencies = [

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 alias b := build
 alias t := test
 mversion := "1.0.0b5"
-zversion := "1.0.0b3"
+zversion := "1.0.0b4"
 quick: fmt fix lint
   @echo "Quick checks passed"
 pre-push: lint fmt-check test

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,7 @@ wheels = [
 
 [[package]]
 name = "ask-shell"
-version = "0.0.4"
+version = "0.0.5"
 source = { editable = "ask-shell" }
 dependencies = [
     { name = "model-lib", extra = ["toml"] },
@@ -1425,5 +1425,5 @@ wheels = [
 
 [[package]]
 name = "zero-3rdparty"
-version = "1.0.0b3"
+version = "1.0.0b4"
 source = { editable = "zero-3rdparty" }

--- a/zero-3rdparty/pyproject.toml
+++ b/zero-3rdparty/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zero-3rdparty"
-version = "1.0.0b3"
+version = "1.0.0b4"
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/zero-3rdparty/zero_3rdparty/__init__.py
+++ b/zero-3rdparty/zero_3rdparty/__init__.py
@@ -1,3 +1,3 @@
 """Files with zero 3rd party dependencies."""
 
-VERSION = "1.0.0b3"
+VERSION = "1.0.0b4"

--- a/zero-3rdparty/zero_3rdparty/file_utils.py
+++ b/zero-3rdparty/zero_3rdparty/file_utils.py
@@ -67,7 +67,8 @@ def clean_dir(
         assert len(Path(path).parents) > expected_parents, (
             f"rm root by accident {path}?"
         )
-    rm_tree_logged(str(path), logger, ignore_errors=ignore_errors)
+    if path.exists():
+        rm_tree_logged(str(path), logger, ignore_errors=ignore_errors)
     if recreate:
         path.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Enhance binary resolution functionality and add tests for the mise command. Ensure the directory exists before attempting to remove it during cleanup. Update version numbers for dependencies.