### PR TITLE
fix: ask-shell add thread safety to next_run_logs_dir and bump version to 0.0.6

### DIFF
--- a/ask-shell/ask_shell/__init__.py
+++ b/ask-shell/ask_shell/__init__.py
@@ -20,7 +20,7 @@ from ask_shell.rich_progress import new_task
 from ask_shell.run_pool import run_pool
 from ask_shell.typer_command import configure_logging
 
-VERSION = "0.0.5"
+VERSION = "0.0.6"
 __all__ = [
     "AskShellSettings",
     "ChoiceTyped",

--- a/ask-shell/pyproject.toml
+++ b/ask-shell/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ask-shell"
-version = "0.0.5"
+version = "0.0.6"
 requires-python = ">=3.10"
 readme = "readme.md"
 dependencies = [


### PR DESCRIPTION
Implement thread safety in the `next_run_logs_dir` method using RLock and update the package version to 0.0.6.